### PR TITLE
staveretting

### DIFF
--- a/Lege.java
+++ b/Lege.java
@@ -23,11 +23,11 @@ class Lege implements Comparable<Lege>{
   }
 
   // Lager en ny MillitaerResept, legger det til utskrevedeResepter, og returnerer det. Bare Spesialister kan skrive ut Narkotiske legemidler.
-  public MillitaerResept skrivMillitaerResept(Legemiddel legemiddel, Pasient pasient, int reit) throws UlovligUtskrift{
+  public Militarresept skrivMillitaerResept(Legemiddel legemiddel, Pasient pasient, int reit) throws UlovligUtskrift{
     // Dersom legen ikke er Spesialist og legemiddelet er Narkotisk, skal det kastes et unntak (UlovligUtskrift).
     if (legemiddel instanceof Narkotisk && this instanceof Spesialist == false) throw new UlovligUtskrift(this, legemiddel);
 
-    MillitaerResept nyResept = new MillitaerResept(legemiddel, this, pasient, reit);
+    Militarresept nyResept = new Militarresept(legemiddel, this, pasient, reit);
     utskrevedeResepter.leggTil(nyResept);
     return nyResept;
   }

--- a/Lenkeliste.java
+++ b/Lenkeliste.java
@@ -180,8 +180,6 @@ public class Lenkeliste<T> implements Liste<T>{
           if(this.compareTo(anna) < 0) return -1;
           return 0;
       }
-      /*
-  
 
 
   }

--- a/Stabel.java
+++ b/Stabel.java
@@ -1,0 +1,12 @@
+public class Stabel<T> extends Lenkeliste<T>{
+
+    public void leggPaa(T ny){
+        leggTil(ny);
+        //legger til i haleenden
+    }
+
+    public T taAv(){
+        return fjern(stoerrelse-1);
+        //fjerner og returnerer fra haleenden
+    }
+}


### PR DESCRIPTION
endra så militærresept -typen ble stavet riktig i Lege